### PR TITLE
chore, docs(README): add CircleCI status badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # BoilerplateClientAngular
 
+|Branch|Status|
+|---|---|
+|development|[![Shift3](https://circleci.com/gh/Shift3/boilerplate-client-angular.svg?style=shield&circle-token=f7e07709887f5d8310779f748d524c40756e2f8a)](https://circleci.com/gh/Shift3/boilerplate-client-angular)|
+|master|[![Shift3](https://circleci.com/gh/Shift3/boilerplate-client-angular/tree/master.svg?style=shield&circle-token=f7e07709887f5d8310779f748d524c40756e2f8a)](https://circleci.com/gh/Shift3/boilerplate-client-angular/tree/master)|
+
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 9.1.6.
 
 ## Development


### PR DESCRIPTION
## Changes

  1. Set up API key on CircleCI for project (necessary while the project is private).
  2. Add markdown table with links to status badges.

## Purpose

The project readme should show CircleCI status badges for the `master` and `development` branch build status.

## Learning

- [Managing API Tokens - CircleCI](https://circleci.com/docs/2.0/managing-api-tokens/)
- [Adding Status Badges - CircleCI](https://circleci.com/docs/2.0/status-badges/)

Closes #47.
References #74.