### PR TITLE
fix(navigation): adjust `routerLink` binding to fix parsing as a literal

### DIFF
--- a/src/app/infrastructure/shared/components/side-navigation/side-navigation.component.html
+++ b/src/app/infrastructure/shared/components/side-navigation/side-navigation.component.html
@@ -1,5 +1,5 @@
 <nav class="nav-container navbar-light">
-  <a class="logo navbar-brand" routerLink="'/'">
+  <a class="logo navbar-brand" [routerLink]="'/'">
     <img src="assets/img/logo.png" alt="Shift3 Technologies">
   </a>
   <div class="link-container">

--- a/src/app/infrastructure/shared/components/top-navigation/top-navigation.component.html
+++ b/src/app/infrastructure/shared/components/top-navigation/top-navigation.component.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light">
-  <a class="navbar-brand" routerLink="'/'">
+  <a class="navbar-brand" [routerLink]="'/'">
     <img src="assets/img/logo.png" alt="Shift3 Technologies">
   </a>
   <button


### PR DESCRIPTION
## Changes

  1. Adjust `routerLink` binding to fix parsing as a literal.

## Purpose

The links in both the side and top navigation logos should work.

Closes #77.