### PR TITLE
chore(github): fix CODEOWNERS; set global ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@karvel @mwallert
+* @karvel @mwallert


### PR DESCRIPTION
## Changes

  1. Set global ownership for code owners.

## Purpose

GitHub code owners should correctly apply to the repository.

Closes #128.