### PR TITLE
fix, refactor(app): handle modal rejection and consolidate logic

### DIFF
--- a/src/app/features/admin/users/user-list/user-list-smart.component.ts
+++ b/src/app/features/admin/users/user-list/user-list-smart.component.ts
@@ -51,7 +51,7 @@ export class UserListSmartComponent implements OnInit {
       message: `Delete ${user.firstName} ${user.lastName}?`,
       action: 'Delete',
     });
-    this.modalService.openConfirmModal(modalConfig).then((isConfirmed) => {
+    this.modalService.openConfirmModal(modalConfig).subscribe((isConfirmed) => {
       if (isConfirmed) {
         this.deleteUser(user);
       }

--- a/src/app/features/content/agents/agent-list/agent-list-smart.component.ts
+++ b/src/app/features/content/agents/agent-list/agent-list-smart.component.ts
@@ -61,7 +61,7 @@ export class AgentListSmartComponent implements OnInit {
       message: `Delete ${agent.name}?`,
       action: 'Delete',
     });
-    this.modalService.openConfirmModal(modalConfig).then((isConfirmed) => {
+    this.modalService.openConfirmModal(modalConfig).subscribe((isConfirmed) => {
       if (isConfirmed) {
         this.deleteAgent(agent);
       }

--- a/src/app/infrastructure/core/services/modal.service.ts
+++ b/src/app/infrastructure/core/services/modal.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import {
+  from,
+  Observable,
+} from 'rxjs';
 
 import { ConfirmModalComponent } from '@shared/components/confirm-modal/confirm-modal.component';
 import { IConfirmModalConfig } from '@models/modal';
@@ -13,12 +17,15 @@ export class ModalService {
     private ngbModalService: NgbModal,
   ) { }
 
-  public openConfirmModal(modalConfig: IConfirmModalConfig): Promise<boolean> {
+  public openConfirmModal(modalConfig: IConfirmModalConfig): Observable<boolean> {
     const modalRef = this.ngbModalService.open(ConfirmModalComponent);
     modalRef.componentInstance.modalConfig = modalConfig;
 
-    return modalRef.result
+    const confirmModal = modalRef.result
       .then((isConfirmed) => (isConfirmed) ? true : false)
       .catch(() => false);
+
+    // Convert to Observable to maintain Angular standards
+    return from(confirmModal);
   }
 }

--- a/src/app/infrastructure/shared/components/navigation/settings/settings.component.ts
+++ b/src/app/infrastructure/shared/components/navigation/settings/settings.component.ts
@@ -39,7 +39,7 @@ export class SettingsComponent {
       message: 'This will end your login session.',
       action: 'Log Out',
     });
-    this.modalService.openConfirmModal(modalConfig).then((isConfirmed) => {
+    this.modalService.openConfirmModal(modalConfig).subscribe((isConfirmed) => {
       if (isConfirmed) {
         this.signOut();
       }


### PR DESCRIPTION
## Changes

  1. Move modal invocation logic to new `ModalService`.
  2. Simplify return to boolean instead of callback method.
  3. Convert response to an observable to maintain expectation of consuming RxJS streams.

## Purpose

Clicking outside of modal or pressing escape to close it should not throw errors. The modal logic should also be consolidated into a service.

Closes #79.
Closes #88.