### PR TITLE
chore(polyfills): add `Array.includes()` polyfill

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -25,7 +25,7 @@ import '@angular/localize/init';
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-// import 'core-js/features/array/includes';
+import 'core-js/features/array/includes';
 
 /**
  * Web Animations `@angular/platform-browser/animations`


### PR DESCRIPTION
## Changes

  1. Add `Array.includes()` polyfill.

## Purpose

The client throws an error on load: 

![image](https://user-images.githubusercontent.com/488032/93545585-a2d94980-f915-11ea-9392-cab2df5bbcf8.png)

The Angular site needed to implement a polyfill for `Array.includes()`.

Closes #153.