### PR TITLE
refactor(features, shared): use `formTitle`, remove dead code

### DIFF
--- a/src/app/features/admin/agency/agency-detail/agency-detail-presentation.component.html
+++ b/src/app/features/admin/agency/agency-detail/agency-detail-presentation.component.html
@@ -1,7 +1,6 @@
 <div class="agency-container">
   <app-dynamic-form
     [formConfig]="formConfig"
-    [formTitle]="formTitle"
     (emitForm)="propagateForm($event)"
     (emitSubmit)="submit()"
   ></app-dynamic-form>

--- a/src/app/features/admin/agency/agency-detail/agency-detail-presentation.component.ts
+++ b/src/app/features/admin/agency/agency-detail/agency-detail-presentation.component.ts
@@ -22,7 +22,6 @@ import { FormGroup } from '@angular/forms';
 export class AgencyDetailPresentationComponent {
   @Input() public agency: IAgencyDTO;
   @Input() public formConfig: IFormConfig = new FormConfig();
-  @Input() public formTitle: string = 'Create Agency';
 
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();

--- a/src/app/features/admin/agency/agency-detail/agency-detail-smart.component.ts
+++ b/src/app/features/admin/agency/agency-detail/agency-detail-smart.component.ts
@@ -31,7 +31,6 @@ import { SaveCancelButtonConfig } from '@models/form/button';
     <app-agency-detail-presentation
       [agency]="agency"
       [formConfig]="formConfig"
-      [formTitle]="formTitle"
       (emitForm)="propagateForm($event)"
       (emitSubmit)="updateOrCreateAgency()"
     ></app-agency-detail-presentation>
@@ -42,7 +41,6 @@ export class AgencyDetailSmartComponent implements OnInit {
   public agency: IAgencyDTO;
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig();
-  public formTitle: string = '';
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -51,7 +49,6 @@ export class AgencyDetailSmartComponent implements OnInit {
     private location: Location,
   ) {
     this.agency = this.activatedRoute.snapshot.data.agency;
-    this.formTitle = this.activatedRoute.snapshot.data.title;
   }
 
   public ngOnInit(): void {
@@ -70,6 +67,7 @@ export class AgencyDetailSmartComponent implements OnInit {
   private buildFormConfig() {
     const formConfig = new FormConfig({
       formName: 'form',
+      formTitle: this.activatedRoute.snapshot.data.title || 'Create Agency',
       submit: new SaveCancelButtonConfig({save: (this.agency?.id) ? 'Update' : 'Create' }),
       controls: [
         new FormField<IInputField>({

--- a/src/app/features/admin/users/user-detail/user-detail-presentation.component.html
+++ b/src/app/features/admin/users/user-detail/user-detail-presentation.component.html
@@ -1,6 +1,5 @@
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/admin/users/user-detail/user-detail-presentation.component.ts
+++ b/src/app/features/admin/users/user-detail/user-detail-presentation.component.ts
@@ -23,7 +23,6 @@ import { IUserDTO } from '@models/user';
 })
 export class UserDetailPresentationComponent {
   @Input() public formConfig: IFormConfig = new FormConfig();
-  @Input() public formTitle: string = 'Create User';
   @Input() public user: IUserDTO;
 
   @Output() public emitForm = new EventEmitter<FormGroup>();

--- a/src/app/features/admin/users/user-detail/user-detail-smart.component.ts
+++ b/src/app/features/admin/users/user-detail/user-detail-smart.component.ts
@@ -44,7 +44,6 @@ import { UserStateService } from '@core/services/state/user-state.service';
 @Component({
   template: `
     <app-user-detail-presentation
-      [formTitle]="formTitle"
       [formConfig]="formConfig"
       [user]="user"
       (emitForm)="propagateForm($event)"
@@ -57,7 +56,6 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
   public checkRole: IRoleCheck;
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig();
-  public formTitle: string = '';
   public isSelf: boolean = false;
   public user: IUserDTO;
 
@@ -72,7 +70,6 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private userStateService: UserStateService,
   ) {
-    this.formTitle = this.activatedRoute.snapshot.data.title;
     this.user = this.activatedRoute.snapshot.data.user;
     this.agencyList = this.activatedRoute.snapshot.data.agencyList;
     this.roleList = this.activatedRoute.snapshot.data.roleList;
@@ -143,6 +140,7 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
   private buildFormConfig() {
     const formConfig = new FormConfig({
       formName: 'form',
+      formTitle: this.activatedRoute.snapshot.data.title || 'Create User',
       submit: new SaveCancelButtonConfig({save: (this.user?.id) ? 'Update' : 'Create' }),
       controls: [
         new FormField<IInputField>({

--- a/src/app/features/auth/activate-account/activate-account-presentation.component.html
+++ b/src/app/features/auth/activate-account/activate-account-presentation.component.html
@@ -1,6 +1,5 @@
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/auth/activate-account/activate-account-presentation.component.ts
+++ b/src/app/features/auth/activate-account/activate-account-presentation.component.ts
@@ -24,8 +24,6 @@ export class ActivateAccountPresentationComponent {
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();
 
-  public formTitle: string = 'Activate Account';
-
   public propagateForm(form: FormGroup): void {
     this.emitForm.emit(form);
   }

--- a/src/app/features/auth/activate-account/activate-account-smart.component.ts
+++ b/src/app/features/auth/activate-account/activate-account-smart.component.ts
@@ -41,6 +41,7 @@ export class ActivateAccountSmartComponent {
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig({
     formName: 'form',
+    formTitle: 'Activate Account',
     submit: new SaveCancelButtonConfig({save: 'Submit'}),
     validation: [ MatchFieldValidation.validFieldMatch('newPassword', 'confirmPassword', 'Password') ],
     controls: [

--- a/src/app/features/auth/forgot-password/forgot-password-presentation.component.html
+++ b/src/app/features/auth/forgot-password/forgot-password-presentation.component.html
@@ -1,7 +1,6 @@
 <p>{{ message?.message }}</p>
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/auth/forgot-password/forgot-password-presentation.component.ts
+++ b/src/app/features/auth/forgot-password/forgot-password-presentation.component.ts
@@ -26,8 +26,6 @@ export class ForgotPasswordPresentationComponent {
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();
 
-  public formTitle: string = 'Forgot Password';
-
   public propagateForm(form: FormGroup): void {
     this.emitForm.emit(form);
   }

--- a/src/app/features/auth/forgot-password/forgot-password-smart.component.ts
+++ b/src/app/features/auth/forgot-password/forgot-password-smart.component.ts
@@ -40,6 +40,7 @@ export class ForgotPasswordSmartComponent {
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig({
     formName: 'form',
+    formTitle: 'Forgot Password',
     submit: new SaveCancelButtonConfig({save: 'Submit'}),
     controls: [
       new FormField<IInputField>({

--- a/src/app/features/auth/login/login-presentation.component.html
+++ b/src/app/features/auth/login/login-presentation.component.html
@@ -3,7 +3,6 @@
     <app-dynamic-form
       id="login-card"
       [formConfig]="formConfig"
-      [formTitle]="formTitle"
       (emitForm)="propagateForm($event)"
       (emitSubmit)="submit()"
     ></app-dynamic-form>

--- a/src/app/features/auth/login/login-presentation.component.ts
+++ b/src/app/features/auth/login/login-presentation.component.ts
@@ -24,8 +24,6 @@ export class LoginPresentationComponent {
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();
 
-  public formTitle: string = 'Member Log In';
-
   public propagateForm(form: FormGroup): void {
     this.emitForm.emit(form);
   }

--- a/src/app/features/auth/login/login-smart.component.ts
+++ b/src/app/features/auth/login/login-smart.component.ts
@@ -40,6 +40,7 @@ export class LoginSmartComponent {
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig({
     formName: 'form',
+    formTitle: 'Member Log In',
     submit: new SaveCancelButtonConfig({save: 'Log In'}),
     controls: [
       new FormField<IInputField>({

--- a/src/app/features/auth/reset-password/reset-password-presentation.component.html
+++ b/src/app/features/auth/reset-password/reset-password-presentation.component.html
@@ -1,6 +1,5 @@
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/auth/reset-password/reset-password-presentation.component.ts
+++ b/src/app/features/auth/reset-password/reset-password-presentation.component.ts
@@ -24,8 +24,6 @@ export class ResetPasswordPresentationComponent {
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();
 
-  public formTitle: string = 'Reset Password';
-
   public propagateForm(form: FormGroup): void {
     this.emitForm.emit(form);
   }

--- a/src/app/features/auth/reset-password/reset-password-smart.component.ts
+++ b/src/app/features/auth/reset-password/reset-password-smart.component.ts
@@ -41,6 +41,7 @@ export class ResetPasswordSmartComponent {
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig({
     formName: 'form',
+    formTitle: 'Reset Password',
     submit: new SaveCancelButtonConfig({save: 'Submit'}),
     validation: [ MatchFieldValidation.validFieldMatch('newPassword', 'confirmPassword', 'Password') ],
     controls: [

--- a/src/app/features/auth/sign-up/sign-up-presentation.component.html
+++ b/src/app/features/auth/sign-up/sign-up-presentation.component.html
@@ -1,6 +1,5 @@
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/auth/sign-up/sign-up-presentation.component.ts
+++ b/src/app/features/auth/sign-up/sign-up-presentation.component.ts
@@ -24,8 +24,6 @@ export class SignUpPresentationComponent {
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();
 
-  public formTitle: string = 'Sign Up';
-
   public propagateForm(form: FormGroup): void {
     this.emitForm.emit(form);
   }

--- a/src/app/features/auth/sign-up/sign-up-smart.component.ts
+++ b/src/app/features/auth/sign-up/sign-up-smart.component.ts
@@ -39,6 +39,7 @@ export class SignUpSmartComponent {
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig({
     formName: 'form',
+    formTitle: 'Sign Up',
     submit: new SaveCancelButtonConfig({save: 'Sign Up'}),
     controls: [
       new FormField<IInputField>({

--- a/src/app/features/content/agents/agent-detail/agent-detail-presentation.component.html
+++ b/src/app/features/content/agents/agent-detail/agent-detail-presentation.component.html
@@ -1,6 +1,5 @@
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/content/agents/agent-detail/agent-detail-presentation.component.ts
+++ b/src/app/features/content/agents/agent-detail/agent-detail-presentation.component.ts
@@ -22,7 +22,6 @@ import { FormGroup } from '@angular/forms';
 })
 export class AgentDetailPresentationComponent {
   @Input() public formConfig: IFormConfig = new FormConfig();
-  @Input() public formTitle: string = 'Create Agent';
   @Input() public agent: IAgentDTO;
 
   @Output() public emitForm = new EventEmitter<FormGroup>();

--- a/src/app/features/content/agents/agent-detail/agent-detail-smart.component.ts
+++ b/src/app/features/content/agents/agent-detail/agent-detail-smart.component.ts
@@ -42,7 +42,6 @@ import { stateList } from '@models/state';
     <app-agent-detail-presentation
       [agent]="agent"
       [formConfig]="formConfig"
-      [formTitle]="formTitle"
       (emitForm)="propagateForm($event)"
       (emitSubmit)="updateOrCreateAgent()"
     ></app-agent-detail-presentation>
@@ -53,7 +52,6 @@ export class AgentDetailSmartComponent implements OnInit {
   public agent: IAgentDTO;
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig();
-  public formTitle: string = '';
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -62,7 +60,6 @@ export class AgentDetailSmartComponent implements OnInit {
     private router: Router,
   ) {
     this.agent = this.activatedRoute.snapshot.data.agent;
-    this.formTitle = this.activatedRoute.snapshot.data.title;
   }
 
   public ngOnInit(): void {
@@ -80,6 +77,7 @@ export class AgentDetailSmartComponent implements OnInit {
   private buildFormConfig() {
     const formConfig = new FormConfig({
       formName: 'form',
+      formTitle: this.activatedRoute.snapshot.data.title || 'Create Agent',
       submit: new SaveCancelButtonConfig({save: (this.agent?.id) ? 'Update' : 'Create' }),
       controls: [
         new FormField<IInputField>({

--- a/src/app/features/user/change-password/change-password-presentation.component.html
+++ b/src/app/features/user/change-password/change-password-presentation.component.html
@@ -1,6 +1,5 @@
 <app-dynamic-form
   [formConfig]="formConfig"
-  [formTitle]="formTitle"
   (emitForm)="propagateForm($event)"
   (emitSubmit)="submit()"
 ></app-dynamic-form>

--- a/src/app/features/user/change-password/change-password-presentation.component.ts
+++ b/src/app/features/user/change-password/change-password-presentation.component.ts
@@ -24,8 +24,6 @@ export class ChangePasswordPresentationComponent {
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();
 
-  public formTitle: string = 'Change Password';
-
   public propagateForm(form: FormGroup): void {
     this.emitForm.emit(form);
   }

--- a/src/app/features/user/change-password/change-password-smart.component.ts
+++ b/src/app/features/user/change-password/change-password-smart.component.ts
@@ -41,6 +41,7 @@ export class ChangePasswordSmartComponent {
   public form: FormGroup = new FormGroup({});
   public formConfig: IFormConfig = new FormConfig({
     formName: 'form',
+    formTitle: 'Change Password',
     submit: new SaveCancelButtonConfig({save: 'Submit'}),
     validation: [ MatchFieldValidation.validFieldMatch('newPassword', 'confirmPassword', 'Password') ],
     controls: [

--- a/src/app/infrastructure/models/form/form.ts
+++ b/src/app/infrastructure/models/form/form.ts
@@ -39,6 +39,7 @@ export class FormField<T> implements IFormField<T> {
 
 export interface IFormConfig {
   formName: string;
+  formTitle: string;
   validation: ValidatorFn[];
   controls: IFormField<IInputField | ISelectField<unknown>>[];
   submit?: ISaveCancelButtonConfig;
@@ -46,6 +47,7 @@ export interface IFormConfig {
 
 export class FormConfig implements IFormConfig {
   formName: string = 'form';
+  formTitle: string = '';
   validation: ValidatorFn[] = [];
   controls: IFormField<IInputField | ISelectField<unknown>>[] = [];
   submit?: ISaveCancelButtonConfig = new SaveCancelButtonConfig();

--- a/src/app/infrastructure/shared/components/dynamic-form/dynamic-form.component.html
+++ b/src/app/infrastructure/shared/components/dynamic-form/dynamic-form.component.html
@@ -1,5 +1,5 @@
 <div class="card">
-  <h2 class="card-header">{{ formTitle }}</h2>
+  <h2 class="card-header">{{ formConfig.formTitle }}</h2>
   <form [formGroup]="form" (ngSubmit)="submit()">
     <ng-container *ngIf="formConfig.controls.length">
       <ng-container

--- a/src/app/infrastructure/shared/components/dynamic-form/dynamic-form.component.ts
+++ b/src/app/infrastructure/shared/components/dynamic-form/dynamic-form.component.ts
@@ -22,7 +22,6 @@ import {
 })
 export class DynamicFormComponent implements OnInit {
   @Input() public formConfig: IFormConfig = new FormConfig();
-  @Input() public formTitle: string = '';
 
   @Output() public emitForm = new EventEmitter<FormGroup>();
   @Output() public emitSubmit = new EventEmitter<void>();


### PR DESCRIPTION
## Changes

  1. Add `formTitle` to `FormConfig`.
  2. Refactor all references.
  3. Remove dead code.

## Purpose

The form title that is displayed in the template is not part of the `FormConfig` class, for reasons I no longer remember.

Closes #149.