### PR TITLE
fix(styles): fix footer in safari

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -14,10 +14,14 @@ const role: RoleType = JSON.parse(localStorage.getItem('user'))?.role?.roleName;
  * This variable sets the default route when navigating to the bare app route (in a logged-in state).
  * It does not handle auth.
  */
-const redirectRoute =
-  role === 'Admin' || role === 'Super Administrator'
-    ? '/admin/user-list'
-    : '/content/agent-list';
+let redirectRoute = '';
+if (role === 'Admin' || role === 'Super Administrator') {
+  redirectRoute = '/admin/user-list';
+} else if (role) {
+  redirectRoute = '/content/agent-list';
+} else {
+  redirectRoute = '/auth/login';
+}
 
 const routes: Routes = [
   {

--- a/src/app/infrastructure/core/guards/auth.guard.spec.ts
+++ b/src/app/infrastructure/core/guards/auth.guard.spec.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject, of as observableOf } from 'rxjs';
 import { AuthGuard } from './auth.guard';
 import { environment } from '@env/environment.test';
 import { Logger } from '@utils/logger';
+import { NotificationService } from '../services/notification.service';
 import { IUserDTO, UserDTO } from '@models/user';
 import { UserStateService } from '../services/state/user-state.service';
 import { RoleCheck } from '@models/role';
@@ -17,6 +18,7 @@ import { RoleCheck } from '@models/role';
       let guard: AuthGuard;
       let userState: UserStateService;
       let injector: TestBed;
+      const notificationMock = { showError: jasmine.createSpy('showError') };
       const routerMock = { navigateByUrl: jasmine.createSpy('navigateByUrl') };
 
       beforeEach(() => {
@@ -24,6 +26,7 @@ import { RoleCheck } from '@models/role';
           providers: [
             AuthGuard,
             UserStateService,
+            { provide: NotificationService, useValue: notificationMock },
             { provide: Router, useValue: routerMock },
           ],
           imports: [HttpClientTestingModule],
@@ -56,6 +59,19 @@ import { RoleCheck } from '@models/role';
           );
           guard.canActivate().subscribe(() => {
             expect(routerMock.navigateByUrl).toHaveBeenCalledWith('/auth');
+          });
+        });
+
+        it(`should show a notification on failing the guard`, () => {
+          spyOn(userState, 'checkRoleList').and.returnValue(
+            observableOf(new RoleCheck()),
+          );
+          const message = [
+            'You cannot view the requested page. Returning to the login page.',
+          ];
+
+          guard.canActivate().subscribe(() => {
+            expect(notificationMock.showError).toHaveBeenCalledWith(message);
           });
         });
 

--- a/src/app/infrastructure/core/guards/auth.guard.ts
+++ b/src/app/infrastructure/core/guards/auth.guard.ts
@@ -4,6 +4,7 @@ import { CanActivate, CanActivateChild, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map, take, tap } from 'rxjs/operators';
 
+import { NotificationService } from '../services/notification.service';
 import { UserStateService } from '../services/state/user-state.service';
 
 @Injectable({
@@ -11,6 +12,7 @@ import { UserStateService } from '../services/state/user-state.service';
 })
 export class AuthGuard implements CanActivate, CanActivateChild {
   constructor(
+    private notificationService: NotificationService,
     private router: Router,
     private userStateService: UserStateService,
   ) {}
@@ -21,6 +23,9 @@ export class AuthGuard implements CanActivate, CanActivateChild {
       map((checkRole) => checkRole.isValid),
       tap((isLoggedInUser) => {
         if (!isLoggedInUser) {
+          const message =
+            'You cannot view the requested page. Returning to the login page.';
+          this.notificationService.showError([message]);
           this.router.navigateByUrl('/auth');
         }
       }),


### PR DESCRIPTION
## Changes

  1. Use `min-height: 100vh;` instead of `height: 100vh;`. 
  2. Improve root route setting to prevent `AuthGuard` from firing unnecessarily.

## Purpose

The footer is placed at what is 100vh of the viewport at the initial render, and it stays there if the user scrolls down:

<img width="1313" alt="Screen Shot 2020-10-06 at 17 51 03" src="https://user-images.githubusercontent.com/488032/95275645-ec72d100-07fd-11eb-89d2-3975135c535d.png">

## Approach

Both Safari and mobile Safari have issues with `height: 100vh`. Hopefully this addresses them without breaking compatibility with the other browsers.

## Learning

<https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/>

Closes #204.