### PR TITLE
fix(readme): Include README with new project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This project is configured as a [template repository](https://docs.github.com/en
 
 ### Initializing the Project
 
-If this project is being cloned to start a new project, there are a few things that need to be updated to make it work. The project name will need to be updated in the `package.json`, `angular.json`, `karma.conf.js`, CircleCI `config.yml`, `app.e2e.spec.ts`, `index.html`, `app.component.ts`, and `app.component.spec.ts` files with the new project name. The README also refers to the boilerplate, both in the text and in the CircleCI badges.
+If this project is being cloned to start a new project, there are a few things that need to be updated to make it work. The project name will need to be updated in the `README.md`, `package.json`, `angular.json`, `karma.conf.js`, CircleCI `config.yml`, `app.e2e.spec.ts`, `index.html`, `app.component.ts`, and `app.component.spec.ts` files with the new project name. The README also refers to the boilerplate, both in the text and in the CircleCI badges.
 
 The project `environment` files will need to be updated with the path to the APIs. The development `environment.ts` assumes a local development server of `http://localhost:3000`, which might need to be updated.
 


### PR DESCRIPTION
## Changes

  1. Self reference README in the case of a fork and/or clone of the project.

## Purpose
Makes sure the developer does not skip out on documentation when forking the project for the first time. 

## Approach
README has sequential steps, so added the change as the first step. 

Closes #212
