### PR TITLE
docs(README): improve yarn documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This boilerplate has a [wiki](https://github.com/Shift3/boilerplate-client-angul
     - [Template Repository](#template-repository)
     - [Initializing the Project](#initializing-the-project)
     - [Yarn](#yarn)
+      - [How to Use `npm` Instead of `yarn`](#how-to-use-npm-instead-of-yarn)
     - [Prettier](#prettier)
     - [Docker](#docker)
     - [CI](#ci)
@@ -89,6 +90,14 @@ After provisioning and before deploying, the `deploy:staging` script in `package
 ### Yarn
 
 This project is configured to use `yarn` instead of `npm`. `yarn` can be installed [here](https://yarnpkg.com/getting-started/install) and its commands are [here](https://yarnpkg.com/getting-started/usage). It is significantly faster than `npm`. `yarn` uses `yarn.lock` as its lockfile instead of the `package-lock.json` from `npm`. `yarn.lock` should be committed and kept current in the project just like `package-lock.json` would be for a project using `npm`.
+
+#### How to Use `npm` Instead of `yarn`
+
+In order to use `npm` instead of `yarn`, the project needs to be updated in a few areas.
+
+- [`angular.json`](angular.json) specifies `yarn` as the package manager on line 5.
+- CircleCI's [`config.yml`](.circleci/config.yml) uses `yarn` instead of `npm` to execute scripts.
+- The `yarn-lock` file should be deleted and the `package-lock.json` file should be committed in its place.
 
 ### Prettier
 


### PR DESCRIPTION
## Changes

  1. Add `yarn` section to readme.
  2. Add instructions to replace `yarn` with `npm`.

## Purpose

The readme should better describe yarn. It should explain how to install and use it, and how to switch the project to `npm`. The current instructions are not prominent, and assume knowledge about `yarn`.

## Testing Steps

#### If you are not a member of this project, _skip this step_

  1. Read through the yarn instructions in the readme.
  2. Please note if they could be clearer or are missing information.

Closes #254.