### PR TITLE
feat(agency-list): Adds static content translation support to agency-list & agency-table components

### DIFF
--- a/src/app/features/admin/admin.module.ts
+++ b/src/app/features/admin/admin.module.ts
@@ -5,9 +5,10 @@ import {
   components as adminComponents,
 } from './admin-routing.module';
 import { SharedModule } from '@shared/shared.module';
+import { TranslocoRootModule } from '@app/transloco/transloco-root.module';
 
 @NgModule({
   declarations: [adminComponents],
-  imports: [SharedModule, AdminRoutingModule],
+  imports: [SharedModule, TranslocoRootModule, AdminRoutingModule],
 })
 export class AdminModule {}

--- a/src/app/features/admin/agency/agency-list/agency-list-presentation.component.html
+++ b/src/app/features/admin/agency/agency-list/agency-list-presentation.component.html
@@ -1,17 +1,20 @@
-<div class="row">
-  <button class="btn btn-add" routerLink="/admin/create-agency">
-    {{ 'Add Agency' | uppercase }}
-  </button>
-</div>
-<ng-container *ngIf="agencyList; else loading">
-  <app-agency-table
-    class="route-content"
-    [tableData]="agencyList"
-    (emitDelete)="deleteAgency($event)"
-  ></app-agency-table>
-</ng-container>
-<ng-template #loading>
-  <div class="table">
-    <div class="loader"></div>
+<ng-container *transloco="let translate; read: 'dynamicForm'">
+  <div class="row">
+    <button class="btn btn-add" routerLink="/admin/create-agency">
+      {{ translate('action.add') | uppercase }}
+      {{ translate('model.agency') | uppercase }}
+    </button>
   </div>
-</ng-template>
+  <ng-container *ngIf="agencyList; else loading">
+    <app-agency-table
+      class="route-content"
+      [tableData]="agencyList"
+      (emitDelete)="deleteAgency($event)"
+    ></app-agency-table>
+  </ng-container>
+  <ng-template #loading>
+    <div class="table">
+      <div class="loader"></div>
+    </div>
+  </ng-template>
+</ng-container>

--- a/src/app/features/admin/agency/agency-table/agency-table.component.html
+++ b/src/app/features/admin/agency/agency-table/agency-table.component.html
@@ -1,38 +1,54 @@
-<table class="table">
-  <thead>
-    <tr>
-      <th scope="col">{{ 'Agency Name' | uppercase }}</th>
-      <th scope="col w-10">{{ 'Actions' | uppercase }}</th>
-    </tr>
-  </thead>
-  <tbody>
-    <ng-container *ngIf="tableData.length">
-      <tr *ngFor="let item of tableData; trackBy: 'id' | trackByKey">
-        <td>{{ item.agencyName }}</td>
-        <td class="w-10">
-          <button
-            class="btn"
-            type="button"
-            tooltip="Update Agency"
-            routerLink="/admin/update-agency/{{ item.id }}"
-          >
-            <span class="fa fa-edit"></span>
-            <span class="sr-only">Update Agency</span>
-          </button>
-          <button
-            class="btn"
-            type="button"
-            tooltip="Delete Agency"
-            (click)="deleteAgency(item)"
-          >
-            <span class="fa fa-trash"></span>
-            <span class="sr-only">Delete Agency</span>
-          </button>
-        </td>
+<ng-container *transloco="let translate">
+  <table class="table">
+    <thead>
+      <tr>
+        <th scope="col">
+          {{ translate('dynamicTable.header.agencyName') | uppercase }}
+        </th>
+        <th scope="col w-10">
+          {{ translate('dynamicTable.header.actions') | uppercase }}
+        </th>
       </tr>
-    </ng-container>
-  </tbody>
-</table>
-<div class="center" *ngIf="!tableData.length">
-  {{ tableConfig?.emptyListMessage }}
-</div>
+    </thead>
+    <tbody>
+      <ng-container *ngIf="tableData.length">
+        <tr *ngFor="let item of tableData; trackBy: 'id' | trackByKey">
+          <td>{{ item.agencyName }}</td>
+          <td class="w-10">
+            <button
+              class="btn"
+              type="button"
+              tooltip="{{ translate('dynamicForm.action.update') }} {{
+                translate('dynamicForm.model.agency')
+              }}"
+              routerLink="/admin/update-agency/{{ item.id }}"
+            >
+              <span class="fa fa-edit"></span>
+              <span class="sr-only"
+                >{{ translate('dynamicForm.action.update') }}
+                {{ translate('dynamicForm.model.agency') }}</span
+              >
+            </button>
+            <button
+              class="btn"
+              type="button"
+              tooltip="{{ translate('dynamicForm.action.delete') }} {{
+                translate('dynamicForm.model.agency')
+              }}"
+              (click)="deleteAgency(item)"
+            >
+              <span class="fa fa-trash"></span>
+              <span class="sr-only"
+                >{{ translate('dynamicForm.action.delete') }}
+                {{ translate('dynamicForm.model.agency') }}</span
+              >
+            </button>
+          </td>
+        </tr>
+      </ng-container>
+    </tbody>
+  </table>
+  <div class="center" *ngIf="!tableData.length">
+    {{ translate('dynamicTable.body.emptyListMessage') }}
+  </div>
+</ng-container>

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -10,12 +10,14 @@
     "model": {
       "account": "Account",
       "agent": "Agent",
+      "agency": "Agency",
       "password": "Password"
     }
   },
   "dynamicTable": {
     "header": {
       "actions": "Actions",
+      "agencyName": "Agency Name",
       "description": "Description",
       "email": "Email",
       "name": "Name",

--- a/src/assets/i18n/es-ES.json
+++ b/src/assets/i18n/es-ES.json
@@ -10,12 +10,14 @@
     "model": {
       "account": "Cuenta",
       "agent": "Agente",
+      "agency": "Agencia",
       "password": "Contraseña"
     }
   },
   "dynamicTable": {
     "header": {
       "actions": "Comportamiento",
+      "agencyName": "Nombre de agencia",
       "description": "Descripción",
       "email": "Correo electrónico",
       "name": "Nombre",

--- a/src/assets/i18n/tl.json
+++ b/src/assets/i18n/tl.json
@@ -10,12 +10,14 @@
     "model": {
       "account": "Account",
       "agent": "Agent",
+      "agency": "Agency",
       "password": "Password"
     }
   },
   "dynamicTable": {
     "header": {
       "actions": "Actions",
+      "agencyName": "Agency Name",
       "description": "Description",
       "email": "Email",
       "name": "Name",

--- a/src/assets/i18n/vi-VN.json
+++ b/src/assets/i18n/vi-VN.json
@@ -10,12 +10,14 @@
     "model": {
       "account": "Tài khoản",
       "agent": "Đặc vụ",
+      "agency": "Đại lý",
       "password": "Mật khẩu"
     }
   },
   "dynamicTable": {
     "header": {
       "actions": "Hành động",
+      "agencyName": "Tên cơ quan",
       "description": "Sự miêu tả",
       "email": "E-mail",
       "name": "Tên",


### PR DESCRIPTION
## Changes
  1. Creates `dynamicTable` property in the JSON files with `header` and `body` nested keys.
  2. These keys hold the key-value pair for agency-table specific labels.

## Purpose
Addresses checkboxes mentioned under the Agencies page in #231 

## Approach
Creating the same structure for `dynamicTable` as that of `dynamicForm` keeps things consistent. 

## Testing steps
#### If you are not a member of this project, _skip this step_
  1. On the Agencies page, check that the following changes in response to language selection:
    1. Table `Add` button text
    2. Table headers
    3. Table tooltip text
