### PR TITLE
refactor(various): Rename t to translate

### DIFF
--- a/src/app/features/auth/login/login-presentation.component.html
+++ b/src/app/features/auth/login/login-presentation.component.html
@@ -1,4 +1,4 @@
-<div class="login-container" *transloco="let t">
+<div class="login-container" *transloco="let translate">
   <div class="form-container">
     <app-dynamic-form
       id="login-card"
@@ -8,15 +8,15 @@
     ></app-dynamic-form>
     <div class="forgot-password-container">
       <a class="forgot-password-link" routerLink="/auth/forgot-password"
-        >{{ t('dynamicForm.action.forgot') }}
-        {{ t('dynamicForm.model.password') }}?</a
+        >{{ translate('dynamicForm.action.forgot') }}
+        {{ translate('dynamicForm.model.password') }}?</a
       >
     </div>
   </div>
   <div class="sign-up-container">
-    <h2 class="card-header">{{ t('signUp.cardHeader') }}</h2>
+    <h2 class="card-header">{{ translate('signUp.cardHeader') }}</h2>
     <div class="instruction">
-      {{ t('signUp.instruction') }}
+      {{ translate('signUp.instruction') }}
     </div>
     <button
       id="form-submit-button"
@@ -25,8 +25,8 @@
       mat-raised-button
       routerLink="/auth/signup"
     >
-      {{ t('dynamicForm.action.create') | uppercase }}
-      {{ t('dynamicForm.model.account') | uppercase }}
+      {{ translate('dynamicForm.action.create') | uppercase }}
+      {{ translate('dynamicForm.model.account') | uppercase }}
     </button>
   </div>
 </div>

--- a/src/app/infrastructure/shared/components/navigation/language-settings/language-settings-presentation.component.html
+++ b/src/app/infrastructure/shared/components/navigation/language-settings/language-settings-presentation.component.html
@@ -1,11 +1,11 @@
-<div ngbDropdown class="navbar-nav" *transloco="let t">
+<div ngbDropdown class="navbar-nav" *transloco="let translate">
   <button
     ngbDropdownToggle
     id="languageDropdown"
     class="nav-link language-button"
   >
     <span class="fa fa-language"></span>
-    {{ t(getObjectProperty(activeLanguage)) | titlecase }}
+    {{ translate(getObjectProperty(activeLanguage)) | titlecase }}
   </button>
   <div
     ngbDropdownMenu
@@ -14,7 +14,7 @@
   >
     <ng-container *ngFor="let language of availableLanguagesForSelection">
       <button ngbDropdownItem (click)="selectLanguage(language)">
-        {{ t(getObjectProperty(language)) | titlecase }}
+        {{ translate(getObjectProperty(language)) | titlecase }}
         <span *ngIf="!activeLangIsDefaultLang" class="default-lang-text">
           / {{ language | titlecase }}
         </span>

--- a/src/app/infrastructure/shared/components/navigation/settings/settings.component.html
+++ b/src/app/infrastructure/shared/components/navigation/settings/settings.component.html
@@ -1,7 +1,7 @@
-<div ngbDropdown class="navbar-nav" *transloco="let t">
+<div ngbDropdown class="navbar-nav" *transloco="let translate">
   <button id="profileDropdown" class="nav-link" ngbDropdownToggle>
     <span class="fa fa-user"></span>
-    {{ t('userProfile.welcomeText') }} {{ loggedInUser?.firstName }}
+    {{ translate('userProfile.welcomeText') }} {{ loggedInUser?.firstName }}
   </button>
   <div
     ngbDropdownMenu
@@ -13,7 +13,7 @@
         <img
           class="profile-photo"
           [src]="loggedInUser.profilePicture || profilePicturePlaceholder"
-          [alt]="t('userProfile.imageAlt')"
+          [alt]="translate('userProfile.imageAlt')"
           (error)="showPlaceholderImageOnEmptyOrError()"
         />
         <div>{{ loggedInUser?.firstName }}</div>
@@ -25,20 +25,20 @@
           *ngFor="let link of profileLinks; trackBy: 'id' | trackByKey"
         >
           <button ngbDropdownItem [routerLink]="link.link">
-            {{ t(getObjectProperty(link.label)) | titlecase }}
+            {{ translate(getObjectProperty(link.label)) | titlecase }}
             <span *ngIf="!activeLangIsDefaultLang" class="default-lang-text">
               / {{ link.label | titlecase }}
             </span>
           </button>
         </ng-container>
         <button ngbDropdownItem (click)="toggleNavBar()">
-          {{ t('userProfile.toggleNavBarText') | titlecase }}
+          {{ translate('userProfile.toggleNavBarText') | titlecase }}
           <span *ngIf="!activeLangIsDefaultLang" class="default-lang-text">
             / {{ defaultLangText.toggleNavBarText | titlecase }}
           </span>
         </button>
         <button ngbDropdownItem (click)="openConfirmModal()">
-          {{ t('userProfile.signOutText') | titlecase }}
+          {{ translate('userProfile.signOutText') | titlecase }}
           <span *ngIf="!activeLangIsDefaultLang" class="default-lang-text">
             / {{ defaultLangText.signOutText | titlecase }}
           </span>

--- a/src/app/infrastructure/shared/components/navigation/side-navigation/side-navigation-presentation.component.html
+++ b/src/app/infrastructure/shared/components/navigation/side-navigation/side-navigation-presentation.component.html
@@ -1,6 +1,6 @@
-<nav class="nav-container navbar-light" *transloco="let t">
+<nav class="nav-container navbar-light" *transloco="let translate">
   <a class="logo navbar-brand" [routerLink]="'/'">
-    <img src="assets/img/logo.png" [alt]="t('logoAlt')" />
+    <img src="assets/img/logo.png" [alt]="translate('logoAlt')" />
   </a>
   <ng-container *ngIf="isValid; else loggedOut">
     <div class="link-container">
@@ -13,7 +13,7 @@
             (click)="isMenuCollapsed = true"
           >
             <span [class]="link.icon"></span>
-            {{ t(getObjectProperty(link.label)) }}
+            {{ translate(getObjectProperty(link.label)) }}
           </button>
           <app-language-settings></app-language-settings>
         </ul>
@@ -34,8 +34,8 @@
         mat-raised-button
         routerLink="/auth/login"
       >
-        {{ t('loginButtonText') | uppercase }} /
-        {{ t('signUpButtonText') | uppercase }}
+        {{ translate('loginButtonText') | uppercase }} /
+        {{ translate('signUpButtonText') | uppercase }}
       </button>
     </div>
   </ng-template>

--- a/src/app/infrastructure/shared/components/navigation/top-navigation/top-navigation-presentation.component.html
+++ b/src/app/infrastructure/shared/components/navigation/top-navigation/top-navigation-presentation.component.html
@@ -1,6 +1,6 @@
-<nav class="navbar navbar-expand-lg navbar-light" *transloco="let t">
+<nav class="navbar navbar-expand-lg navbar-light" *transloco="let translate">
   <a class="navbar-brand" [routerLink]="'/'">
-    <img src="assets/img/logo.png" [alt]="t('logoAlt')" />
+    <img src="assets/img/logo.png" [alt]="translate('logoAlt')" />
   </a>
 
   <ng-container *ngIf="isValid; else loggedOut">
@@ -24,7 +24,7 @@
             (click)="isMenuCollapsed = true"
           >
             <span [class]="link.icon"></span>
-            {{ t(getObjectProperty(link.label)) }}
+            {{ translate(getObjectProperty(link.label)) }}
           </button>
           <app-language-settings></app-language-settings>
         </ul>
@@ -45,8 +45,8 @@
         mat-raised-button
         routerLink="/auth/login"
       >
-        {{ t('loginButtonText') | uppercase }} /
-        {{ t('signUpButtonText') | uppercase }}
+        {{ translate('loginButtonText') | uppercase }} /
+        {{ translate('signUpButtonText') | uppercase }}
       </button>
     </div>
   </ng-template>


### PR DESCRIPTION
## Changes
1. Renames `t` variable on structural transloco directive to `translate` in the following components:
  1. login
  2. language-settings
  3. settings
  4. side-navigation
  5. top-navigation

## Purpose
To address feedback shared on #252 regarding the variable name.

