### PR TITLE
feat(index): remove text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,6 @@
       <div class="preload-container">
         <div class="preload-child">
           <div class="loader"></div>
-          <span style="padding: 20px"> LOADING... </span>
         </div>
       </div>
     </app-root>


### PR DESCRIPTION
## Changes

- [x] Remove text from `index.html`.

## Purpose

The webapp should not have text that cannot easily be translated. The preload screen (what shows when an Angular webapp is initially loading) has an animated spinner to indicate loading and does not also need text. The preload screen shows an animated spinner and the text "LOADING...". This is directly in the webapp's `index.html` file and is displayed before transloco can translate it.

## Testing Steps

#### If you are not a member of this project, _skip this step_

_How do the users test this change?_

  1. Load the site (clear the cache if the preload screen does not appear).
  2. Confirm that there is no text, only an animated spinner.

Closes #281.