### PR TITLE
fix(various): renames roleName to roleKey across the app

### DIFF
--- a/src/app/features/admin/users/user-detail/user-detail-smart.component.ts
+++ b/src/app/features/admin/users/user-detail/user-detail-smart.component.ts
@@ -208,7 +208,7 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
         label: dynamicFormTranslationKeys.label.role,
         fieldConfig: new SelectField({
           options: this.roleList,
-          optionName: 'roleName',
+          optionName: 'roleKey',
           optionValue: 'id',
         }),
         validation: [RequiredValidation.required('Role')],

--- a/src/app/features/admin/users/user-list/user-table/user-table.component.html
+++ b/src/app/features/admin/users/user-list/user-table/user-table.component.html
@@ -56,7 +56,7 @@
           <ng-container *ngIf="checkRole?.isSuperAdmin">
             <td>{{ item.agency.agencyName }}</td>
           </ng-container>
-          <td>{{ item.role.roleName }}</td>
+          <td>{{ item.role.roleKey }}</td>
           <td>
             <ng-container *ngIf="item.activatedAt; else resendEmail">
               {{ item.activatedAt | date }}

--- a/src/app/infrastructure/core/guards/admin-auth.guard.spec.ts
+++ b/src/app/infrastructure/core/guards/admin-auth.guard.spec.ts
@@ -81,7 +81,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 2,
-                roleName: 'User',
+                roleKey: 'User',
               },
             }),
           );
@@ -99,7 +99,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 2,
-                roleName: 'Admin',
+                roleKey: 'Admin',
               },
             }),
           );
@@ -117,7 +117,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 2,
-                roleName: 'Super Administrator',
+                roleKey: 'Super Administrator',
               },
             }),
           );
@@ -135,7 +135,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 2,
-                roleName: 'Editor',
+                roleKey: 'Editor',
               },
             }),
           );

--- a/src/app/infrastructure/core/guards/auth.guard.spec.ts
+++ b/src/app/infrastructure/core/guards/auth.guard.spec.ts
@@ -99,7 +99,7 @@ import { RoleCheck } from '@models/role';
               lastName: 'Tester',
               role: {
                 id: 2,
-                roleName: 'User',
+                roleKey: 'User',
               },
             }),
           );

--- a/src/app/infrastructure/core/guards/can-edit-auth.guard.spec.ts
+++ b/src/app/infrastructure/core/guards/can-edit-auth.guard.spec.ts
@@ -82,7 +82,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 4,
-                roleName: 'User',
+                roleKey: 'User',
               },
             }),
           );
@@ -100,7 +100,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 3,
-                roleName: 'Editor',
+                roleKey: 'Editor',
               },
             }),
           );
@@ -118,7 +118,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 1,
-                roleName: 'Admin',
+                roleKey: 'Admin',
               },
             }),
           );
@@ -136,7 +136,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 2,
-                roleName: 'Super Administrator',
+                roleKey: 'Super Administrator',
               },
             }),
           );
@@ -154,7 +154,7 @@ import { UserStateService } from '../services/state/user-state.service';
               lastName: 'Tester',
               role: {
                 id: 4,
-                roleName: 'User',
+                roleKey: 'User',
               },
             }),
           );

--- a/src/app/infrastructure/core/guards/redirect-routes.guard.spec.ts
+++ b/src/app/infrastructure/core/guards/redirect-routes.guard.spec.ts
@@ -53,7 +53,7 @@ import { UserStateService } from '../services/state/user-state.service';
           const testUser$ = new BehaviorSubject<IUserDTO>(
             new UserDTO({
               role: new RoleDTO({
-                roleName: 'Admin',
+                roleKey: 'Admin',
               }),
             }),
           );
@@ -68,7 +68,7 @@ import { UserStateService } from '../services/state/user-state.service';
           const testUser$ = new BehaviorSubject<IUserDTO>(
             new UserDTO({
               role: new RoleDTO({
-                roleName: 'Editor',
+                roleKey: 'Editor',
               }),
             }),
           );

--- a/src/app/infrastructure/core/resolvers/get-role-list.resolver.spec.ts
+++ b/src/app/infrastructure/core/resolvers/get-role-list.resolver.spec.ts
@@ -54,7 +54,7 @@ import { RoleService } from '../services/api/role.service';
         it('should resolve the user role object in an array', () => {
           const expectedValue = new Array<RoleDTO>({
             id: 0,
-            roleName: '',
+            roleKey: '',
           });
           spyOn(service, 'getRoleList').and.returnValue(
             observableOf(expectedValue),

--- a/src/app/infrastructure/core/services/api/auth.service.spec.ts
+++ b/src/app/infrastructure/core/services/api/auth.service.spec.ts
@@ -49,7 +49,7 @@ import { UserStateService } from '../state/user-state.service';
           profilePicture: null,
           role: {
             id: 1,
-            roleName: 'User',
+            roleKey: 'User',
           },
         });
         testUserSession = {
@@ -69,7 +69,7 @@ import { UserStateService } from '../state/user-state.service';
             },
             role: {
               id: 1,
-              roleName: 'User',
+              roleKey: 'User',
             },
           },
           jwtToken:

--- a/src/app/infrastructure/core/services/api/role.service.spec.ts
+++ b/src/app/infrastructure/core/services/api/role.service.spec.ts
@@ -47,7 +47,7 @@ import { RoleService } from './role.service';
           const expectedValue: IRoleDTO[] = [
             {
               id: 1,
-              roleName: 'User',
+              roleKey: 'User',
             },
           ];
           let response: IRoleDTO[];

--- a/src/app/infrastructure/core/services/api/user.service.spec.ts
+++ b/src/app/infrastructure/core/services/api/user.service.spec.ts
@@ -70,7 +70,7 @@ import { IMessage } from '@models/message';
           profilePicture: null,
           role: {
             id: 1,
-            roleName: 'User',
+            roleKey: 'User',
           },
         });
         testUserSession = {
@@ -90,7 +90,7 @@ import { IMessage } from '@models/message';
             },
             role: {
               id: 1,
-              roleName: 'User',
+              roleKey: 'User',
             },
           },
           jwtToken:

--- a/src/app/infrastructure/core/services/state/user-state.service.spec.ts
+++ b/src/app/infrastructure/core/services/state/user-state.service.spec.ts
@@ -28,7 +28,7 @@ import { UserStateService } from './user-state.service';
             lastName: 'Tester',
             role: {
               id: 2,
-              roleName: 'Super Administrator',
+              roleKey: 'Super Administrator',
             },
           }),
         );
@@ -38,7 +38,7 @@ import { UserStateService } from './user-state.service';
             lastName: 'Tester',
             role: {
               id: 1,
-              roleName: 'Admin',
+              roleKey: 'Admin',
             },
           }),
         );
@@ -105,7 +105,7 @@ import { UserStateService } from './user-state.service';
             },
             role: {
               id: 0,
-              roleName: '',
+              roleKey: '',
             },
           };
           service.setUserSession(testUser);
@@ -155,7 +155,7 @@ import { UserStateService } from './user-state.service';
               lastName: 'Tester',
               role: {
                 id: 3,
-                roleName: 'User',
+                roleKey: 'User',
               },
             }),
           );
@@ -174,7 +174,7 @@ import { UserStateService } from './user-state.service';
               lastName: 'Tester',
               role: {
                 id: 3,
-                roleName: 'Editor',
+                roleKey: 'Editor',
               },
             }),
           );
@@ -198,7 +198,7 @@ import { UserStateService } from './user-state.service';
               lastName: 'Tester',
               role: {
                 id: 3,
-                roleName: 'Admin',
+                roleKey: 'Admin',
               },
             }),
           );
@@ -222,7 +222,7 @@ import { UserStateService } from './user-state.service';
               lastName: 'Tester',
               role: {
                 id: 3,
-                roleName: 'Super Administrator',
+                roleKey: 'Super Administrator',
               },
             }),
           );

--- a/src/app/infrastructure/core/services/state/user-state.service.ts
+++ b/src/app/infrastructure/core/services/state/user-state.service.ts
@@ -36,7 +36,7 @@ export class UserStateService {
    */
   public checkRoleList(): Observable<IRoleCheck> {
     return this.getUserSession().pipe(
-      map((user) => user?.role?.roleName),
+      map((user) => user?.role?.roleKey),
       map((roleName) => {
         const roleList: IRoleCheck = new RoleCheck({
           canEdit: RoleDTO.canEdit(roleName),

--- a/src/app/infrastructure/models/role.ts
+++ b/src/app/infrastructure/models/role.ts
@@ -2,12 +2,12 @@ export type RoleType = 'Admin' | 'Editor' | 'User' | 'Super Administrator' | '';
 
 export interface IRoleDTO {
   id: number;
-  roleName: RoleType;
+  roleKey: RoleType;
 }
 
 export class RoleDTO implements IRoleDTO {
   id: number = 0;
-  roleName: RoleType = '';
+  roleKey: RoleType = '';
 
   static isValidRoleType(role: RoleType): role is RoleType {
     return ['Admin', 'Editor', 'User', 'Super Administrator'].includes(role);


### PR DESCRIPTION
## Changes

  1. Renames all occurrences of `roleName` to `roleKey` post server-side changes made to the role entity.

## Purpose
Update client-side role model to be in sync with the server-side role entity.

## Pre-Testing TODOs
  1. Run the migrations on the server (if not already done) as described [here](https://github.com/Shift3/boilerplate-server-node/pull/206).

## Testing Steps
1. Login and make sure your user permissions access are the same.
