### PR TITLE
fix(agent-detail): fix the language code in the payload

### DIFF
--- a/src/app/features/content/agents/agent-detail/agent-detail-smart.component.ts
+++ b/src/app/features/content/agents/agent-detail/agent-detail-smart.component.ts
@@ -220,7 +220,6 @@ export class AgentDetailSmartComponent implements OnInit {
       this.form,
       dynamicContentDTO,
     );
-    console.log(this.languageCode);
     payload.dynamicContent = {
       [this.languageCode]: dynamicContentPayload,
     };


### PR DESCRIPTION
## Changes
  1. Fixes the language code that is set to the `dynamicContent` key by setting it to the `languageCode` variable in the component

## Approach
The `languageCode` local variable is set to the language for which a translation is being added or the default app language. So utilizing it as part of the payload works best.

## Testing Steps
#### If you are not a member of this project, _skip this step_

  1. Login & go to Agent list view.
  2. Create/Update a record.
  3. Click on the submit button & check the network tab to view the payload. It should look like:
  ```
    body: {
      "fullName": "",
        ...
        "dynamicContent": {
          "en-US": {
            "description": ""
          }
        }
    }
  ```
  4. Attempt to add a translation for any language.
  5. Submit the form & verify that the payload looks like the above with the language-code matching that in the route.
  7. Change the language selection from the navigation dropdown. Submit any of the above-mentioned forms and verify that the language code in the payload is still the app default language (en-US in this case).

Closes #318
