### PR TITLE
chore(README): GitHub Badge should match default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | Branch      | Status                                                                                                                                                                                                                           |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | development | [![Shift3](https://circleci.com/gh/Shift3/boilerplate-client-angular.svg?style=shield&circle-token=f7e07709887f5d8310779f748d524c40756e2f8a)](https://circleci.com/gh/Shift3/boilerplate-client-angular)                         |
-| master      | [![Shift3](https://circleci.com/gh/Shift3/boilerplate-client-angular/tree/master.svg?style=shield&circle-token=f7e07709887f5d8310779f748d524c40756e2f8a)](https://circleci.com/gh/Shift3/boilerplate-client-angular/tree/master) |
+| main      | [![Shift3](https://circleci.com/gh/Shift3/boilerplate-client-angular/tree/main.svg?style=shield&circle-token=f7e07709887f5d8310779f748d524c40756e2f8a)](https://circleci.com/gh/Shift3/boilerplate-client-angular/tree/main) |
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 9.1.6.
 


### PR DESCRIPTION
## Changes

  1. Default branch name in GitHub is now `main` which replaces `master`.
  2. Update the CI badge and branch reference in the README.

## Purpose
We should align our boilerplate projects with GitHubs own standards in order to reduce confusion when using our products. 

## Approach

The release as well as the default GitHub branch has been changed to main.

Closes #156.