### PR TITLE
feat(services): handle server translated messages

### DIFF
--- a/src/app/infrastructure/core/services/global-error-handler.service.ts
+++ b/src/app/infrastructure/core/services/global-error-handler.service.ts
@@ -43,7 +43,7 @@ export class GlobalErrorHandlerService implements ErrorHandler {
     error: Error | HttpErrorResponse,
     errorMessage: IMessage[] | IMessage,
     sentryConfig: ISentryConfig,
-    isFromServer: boolean = false,
+    isServerTranslated: boolean = false,
   ): void {
     const notifier = this.injector.get(NotificationService);
     if (!Array.isArray(errorMessage)) {
@@ -51,7 +51,7 @@ export class GlobalErrorHandlerService implements ErrorHandler {
         errorMessage,
       );
     }
-    notifier.showError(errorMessage, isFromServer);
+    notifier.showError(errorMessage, isServerTranslated);
     if (sentryConfig.sendToSentry) {
       this.errorService.logError(
         error,

--- a/src/app/infrastructure/core/services/notification.service.ts
+++ b/src/app/infrastructure/core/services/notification.service.ts
@@ -17,9 +17,12 @@ export class NotificationService {
 
   public showSuccess(
     messageList: Message[],
-    isFromServer: boolean = false,
+    isServerTranslated: boolean = false,
   ): void {
-    const formattedMessage = this.formatMessageList(messageList, isFromServer);
+    const formattedMessage = this.formatMessageList(
+      messageList,
+      isServerTranslated,
+    );
     // Wrap notification call in zone invocation to fix rendering inconsistencies when using `Injector`
     this.zone.run(() => {
       this.toastr.success(formattedMessage, '', { enableHtml: true });
@@ -28,9 +31,12 @@ export class NotificationService {
 
   public showError(
     messageList: Message[],
-    isFromServer: boolean = false,
+    isServerTranslated: boolean = false,
   ): void {
-    const formattedMessage = this.formatMessageList(messageList, isFromServer);
+    const formattedMessage = this.formatMessageList(
+      messageList,
+      isServerTranslated,
+    );
     // Wrap notification call in zone invocation to fix rendering inconsistencies when using `Injector`
     this.zone.run(() => {
       this.toastr.error(formattedMessage, '', {
@@ -42,21 +48,21 @@ export class NotificationService {
 
   private formatMessageList(
     messageList: Message[],
-    isFromServer: boolean = false,
+    isServerTranslated: boolean = false,
   ): string {
     const translatedMessageList: string[] = this.translateMessageList(
       messageList,
-      isFromServer,
+      isServerTranslated,
     );
     return translatedMessageList.join('<br />');
   }
 
   private translateMessageList(
     messageList: Message[],
-    isFromServer: boolean = false,
+    isServerTranslated: boolean = false,
   ): string[] {
     return messageList.map((message: Message) => {
-      if (message.type === 'static' && !isFromServer)
+      if (message.type === 'static' && !isServerTranslated)
         return this.languageStateService.getTranslation(message.message);
 
       return message.message;


### PR DESCRIPTION
## Changes

  - [x]  Add a `isServerTranslated` flag with default value of false to the `NotificationService` methods.
  - [x]  Only try translating the message when `isServerTranslated` is true.
  - [x]  Pass the true value from the server error statements in the `handleError()` semaphore.

## Purpose

The client should not try to translate server-translated messages.

Currently, the client tries to translate all messages passed through to the `NotificationService`. When given a translated string from the server, the service falls back to serving the message as is, but the translation library, transloco, logs  a missing translation key error.

## Approach

This addresses the problem with a new flag. The flag has a default value to minimize the delta.

## Testing Steps

#### If you are not a member of this project, _skip this step_

_How do the users test this change?_

  1. Cause a server side error (logging in with the wrong credentials is an easy test).
  2. Confirm that the error toast shows correctly.
  3. Confirm that no error about missing keys appears in the console.
  4. Try again in other languages.
  5. Confirm that no error about missing keys appears in the console.
  6. Trigger a client side message (adding or deleting a user, agency, or agent, resending activation email, and resetting user passwords all show client side messages).
  7. Confirm that the success message shows correctly.
  8. Try again in other languages.
  9. Confirm that the success message shows correctly.

Closes #326.