### PR TITLE
fix(app): prevent accidental reassignment in request payloads

### DIFF
--- a/src/app/features/admin/users/user-detail/user-detail-smart.component.ts
+++ b/src/app/features/admin/users/user-detail/user-detail-smart.component.ts
@@ -10,14 +10,14 @@ import { FormGroup } from '@angular/forms';
 
 import { Subscription } from 'rxjs';
 
-import { IAgencyDTO } from '@models/agency';
+import { AgencyDTO, IAgencyDTO } from '@models/agency';
 import { ChangeUserRequest, IChangeUserRequest, IUserDTO } from '@models/user';
 import { EmailValidation } from '@utils/validation/email-validation';
 import { FormConfig, FormField, IFormConfig } from '@models/form/form';
 import { FormService } from '@core/services/form.service';
 import { IInputField, InputField } from '@models/form/input';
 import { RequiredValidation } from '@utils/validation/required-validation';
-import { IRoleCheck, RoleType } from '@models/role';
+import { IRoleCheck, RoleDTO, RoleType } from '@models/role';
 import { SaveCancelButtonConfig } from '@models/form/button';
 import { ISelectField, ISelectOptions, SelectField } from '@models/form/select';
 import { UserService } from '@core/services/api/user.service';
@@ -125,12 +125,22 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
   private buildPayload(): IChangeUserRequest {
     const payloadDTO = new ChangeUserRequest();
     const payload = this.formService.buildRequestPayload(this.form, payloadDTO);
-    // Set unique values that diverges from the `FormGroup` here
+    // Set unique values that diverge from the `FormGroup` here
     if (this.checkRole.isSuperAdmin && !this.isSelf) {
-      payload.agency.agencyName = this.form.get('agencyName').value;
+      const agencyDTO = new AgencyDTO();
+      const agencyPayload = this.formService.buildNestedRequestPayload(
+        this.form,
+        agencyDTO,
+      );
+      payload.agency = agencyPayload;
     }
     if (!this.isSelf) {
-      payload.role.id = this.form.get('roleId').value;
+      const roleDTO = new RoleDTO();
+      const rolePayload = this.formService.buildNestedRequestPayload(
+        this.form,
+        roleDTO,
+      );
+      payload.role = rolePayload;
     }
     return payload;
   }
@@ -184,7 +194,7 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
     // Add agency control only if the user is a Super Administrator.
     if (this.checkRole.isSuperAdmin && !this.isSelf) {
       const agencyList = new FormField<ISelectField<IAgencyDTO>>({
-        name: 'agencyName',
+        name: 'agency.agencyName',
         value: this.user?.agency.agencyName,
         fieldType: 'select',
         label: dynamicFormTranslationKeys.label.agency,
@@ -202,7 +212,7 @@ export class UserDetailSmartComponent implements OnInit, OnDestroy {
     // Add role control if the user is not the logged in user.
     if (!this.isSelf) {
       const roleList = new FormField<ISelectField<RoleType>>({
-        name: 'roleId',
+        name: 'role.roleId',
         value: this.user?.role.id,
         fieldType: 'select',
         label: dynamicFormTranslationKeys.label.role,

--- a/src/app/features/content/agents/agent-detail/agent-detail-smart.component.ts
+++ b/src/app/features/content/agents/agent-detail/agent-detail-smart.component.ts
@@ -217,7 +217,7 @@ export class AgentDetailSmartComponent implements OnInit {
     payload.address = addressPayload;
 
     const dynamicContentDTO = new AgentTranslation();
-    const dynamicContentPayload = this.formService.buildRequestPayload(
+    const dynamicContentPayload = this.formService.buildNestedRequestPayload(
       this.form,
       dynamicContentDTO,
     );

--- a/src/app/infrastructure/core/services/form.service.spec.ts
+++ b/src/app/infrastructure/core/services/form.service.spec.ts
@@ -165,6 +165,47 @@ import { RequiredValidation } from '@utils/validation/required-validation';
             expectedValue,
           );
         });
+      });
+
+      describe('buildNestedRequestPayload()', () => {
+        const formService = new FormService(new FormBuilder());
+        it(`should return a populated request object with values from matching form values`, () => {
+          const requestPayload = new LoginRequest();
+          const expectedValue = new LoginRequest();
+          const form = new FormGroup({});
+          form.addControl('email', new FormControl('test@test.com'));
+          form.addControl('password', new FormControl('password'));
+          expectedValue.email = 'test@test.com';
+          expectedValue.password = 'password';
+          expect(
+            formService.buildNestedRequestPayload(form, requestPayload),
+          ).toEqual(expectedValue);
+        });
+
+        it(`should return a partially populated object with values from partially matching form values`, () => {
+          const payload = new LoginRequest();
+          const expectedValue = new LoginRequest();
+          const form = new FormGroup({});
+          form.addControl('email', new FormControl('test@test.com'));
+          form.addControl('test', new FormControl('test'));
+          expectedValue.email = 'test@test.com';
+          expectedValue.password = '';
+          expect(formService.buildNestedRequestPayload(form, payload)).toEqual(
+            expectedValue,
+          );
+        });
+
+        it(`should return an initialized request object when no matching form values are found`, () => {
+          const payload = new LoginRequest();
+          const expectedValue = new LoginRequest();
+          const form = new FormGroup({});
+          form.addControl('test', new FormControl('test'));
+          expectedValue.email = '';
+          expectedValue.password = '';
+          expect(formService.buildNestedRequestPayload(form, payload)).toEqual(
+            expectedValue,
+          );
+        });
 
         it(`should return a populated object with nested values`, () => {
           const dynamicContentPayload = new AgentTranslation();
@@ -178,7 +219,7 @@ import { RequiredValidation } from '@utils/validation/required-validation';
             new FormControl('Test User Description'),
           );
           expect(
-            formService.buildRequestPayload(form, dynamicContentPayload),
+            formService.buildNestedRequestPayload(form, dynamicContentPayload),
           ).toEqual(expectedValue);
         });
       });

--- a/src/app/infrastructure/core/services/form.service.spec.ts
+++ b/src/app/infrastructure/core/services/form.service.spec.ts
@@ -1,8 +1,4 @@
-import {
-  AgentRequest,
-  AgentTranslation,
-  AgentTranslationList,
-} from '@models/agent';
+import { AgentTranslation } from '@models/agent';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 
 import { environment } from '@env/environment.test';

--- a/src/app/infrastructure/core/services/form.service.ts
+++ b/src/app/infrastructure/core/services/form.service.ts
@@ -73,13 +73,25 @@ export class FormService {
       if (requestPayload.hasOwnProperty(property)) {
         if (form.controls[property]?.value) {
           requestPayload[property] = form.controls[property].value;
-        } else {
-          const nestedProperty: string = Object.keys(form.controls).find(
-            (k) => k.toLowerCase().indexOf(property.toLowerCase()) > -1,
-          );
-          if (nestedProperty?.includes('dynamicContent')) {
-            requestPayload[property] = form.controls[nestedProperty].value;
-          }
+        }
+      }
+    }
+
+    return requestPayload;
+  }
+
+  /**
+   * Build a request payload and map to nested values from the matching `FormGroup` values.
+   * Does not handle conditional logic.
+   */
+  public buildNestedRequestPayload<T>(form: FormGroup, requestPayload: T): T {
+    for (const property in requestPayload) {
+      if (requestPayload.hasOwnProperty(property)) {
+        const nestedProperty: string = Object.keys(form.controls).find(
+          (k) => k.toLowerCase().indexOf(property.toLowerCase()) > -1,
+        );
+        if (nestedProperty) {
+          requestPayload[property] = form.controls[nestedProperty].value;
         }
       }
     }

--- a/src/app/infrastructure/core/services/form.service.ts
+++ b/src/app/infrastructure/core/services/form.service.ts
@@ -77,7 +77,7 @@ export class FormService {
           const nestedProperty: string = Object.keys(form.controls).find(
             (k) => k.toLowerCase().indexOf(property.toLowerCase()) > -1,
           );
-          if (nestedProperty) {
+          if (nestedProperty?.includes('dynamicContent')) {
             requestPayload[property] = form.controls[nestedProperty].value;
           }
         }

--- a/src/app/infrastructure/core/services/form.service.ts
+++ b/src/app/infrastructure/core/services/form.service.ts
@@ -71,7 +71,7 @@ export class FormService {
   public buildRequestPayload<T>(form: FormGroup, requestPayload: T): T {
     for (const property in requestPayload) {
       if (requestPayload.hasOwnProperty(property)) {
-        if (form.controls[property] && form.controls[property].value) {
+        if (form.controls[property]?.value) {
           requestPayload[property] = form.controls[property].value;
         } else {
           const nestedProperty: string = Object.keys(form.controls).find(

--- a/src/app/infrastructure/core/services/state/language-state.service.spec.ts
+++ b/src/app/infrastructure/core/services/state/language-state.service.spec.ts
@@ -107,6 +107,7 @@ import { translocoConfigObj } from '@app/transloco/transloco-config';
         it('should return the default language for any language that is not supported by the application', () => {
           const language: string = 'Russian';
           const expectedValue = translocoConfigObj.defaultLang;
+          spyOn(Logger, 'warn');
 
           expect(service.getLanguageCodeFromLanguage(language)).toEqual(
             expectedValue,
@@ -191,6 +192,7 @@ import { translocoConfigObj } from '@app/transloco/transloco-config';
         it('should fall back to the default language for active language when given a non-supported value', () => {
           const mockNewLang = 'french';
           const expectedValue = 'english';
+          spyOn(Logger, 'warn');
           translocoServiceMock.getActiveLang.and.returnValue('en-US');
           service.selectLanguage(mockNewLang);
           expect(service.activeLanguage$.getValue()).toEqual(expectedValue);

--- a/src/app/infrastructure/core/services/state/language-state.service.spec.ts
+++ b/src/app/infrastructure/core/services/state/language-state.service.spec.ts
@@ -51,12 +51,14 @@ import { translocoConfigObj } from '@app/transloco/transloco-config';
 
       describe('getActiveLangIsDefaultLang()', () => {
         it('should return as an Observable', () => {
-          const mockCurrentActiveLang = 'english';
-          service.setActiveLanguage(mockCurrentActiveLang);
-
-          const testActiveLang$ = new BehaviorSubject<boolean>(false);
-          const expectedValue = testActiveLang$.asObservable();
-
+          const mockActiveLangIsDefaultLang$ = new BehaviorSubject<boolean>(
+            true,
+          );
+          const testActiveLangIsDefaultLang$ = new BehaviorSubject<boolean>(
+            true,
+          );
+          const expectedValue = testActiveLangIsDefaultLang$.asObservable();
+          service.activeLangIsDefaultLang$ = mockActiveLangIsDefaultLang$;
           expect(service.getActiveLangIsDefaultLang()).toEqual(expectedValue);
         });
       });

--- a/src/app/infrastructure/models/user.ts
+++ b/src/app/infrastructure/models/user.ts
@@ -39,7 +39,7 @@ export interface IForgotPasswordRequest {
 export class ForgotPasswordRequest implements IForgotPasswordRequest {
   email: string = '';
 
-  constructor(configOverride?: IForgotPasswordRequest) {
+  constructor(configOverride?: Partial<IForgotPasswordRequest>) {
     if (configOverride) {
       Object.assign(this, configOverride);
     }
@@ -55,7 +55,7 @@ export class ResetPasswordRequest implements IResetPasswordRequest {
   newPassword: string = '';
   confirmPassword: string = '';
 
-  constructor(configOverride?: IResetPasswordRequest) {
+  constructor(configOverride?: Partial<IResetPasswordRequest>) {
     if (configOverride) {
       Object.assign(this, configOverride);
     }
@@ -73,7 +73,7 @@ export class ChangePasswordRequest implements IChangePasswordRequest {
   newPassword: string = '';
   confirmPassword: string = '';
 
-  constructor(configOverride?: IChangePasswordRequest) {
+  constructor(configOverride?: Partial<IChangePasswordRequest>) {
     if (configOverride) {
       Object.assign(this, configOverride);
     }
@@ -97,7 +97,7 @@ export class ChangeUserRequest implements IChangeUserRequest {
   agency: IAgencyDTO = new AgencyDTO();
   role: IRoleDTO = new RoleDTO();
 
-  constructor(configOverride?: IChangeUserRequest) {
+  constructor(configOverride?: Partial<IChangeUserRequest>) {
     if (configOverride) {
       Object.assign(this, configOverride);
     }


### PR DESCRIPTION
## Changes

  - [x] Create new `buildNestedRequestPayload()`.
  - [x] Move nested property logic.
  - [x] Add tests.
  - [x] Use `buildNestedRequestPayload()` when unpacking `dynamicContent`.
  - [x] Use `buildNestedRequestPayload()` when mapping from nested property to parent object (e.g. getting form values for role and agency from select fields).
  - [x] Fix breaking test in `LanguageStateService`.

## Purpose

Unpacking nested payloads should not be a side effect for `buildRequestPayload()`. It should be separated into its own method for clarity.

The current method can accidentally overwrite objects with nested values:

```ts
{
    id: 1,
    name: 'Test Tester',
    ...
    role: {
        id: 1,
        roleName: 'Admin'
    },
    agency: {
        id: 1,
        agencyName: 'TestCo'
    }
}
```

becomes

```ts
{
    id: 1,
    name: 'Test Tester',
    ...
    role: 1,
    agency: 'TestCo'
}
```

## Approach

_How does this change address the problem?_

## Pre-Testing TODOs

_What needs to be done before testing._

  1. Serve from the translation epic branch on the API.

## Testing Steps

#### If you are not a member of this project, _skip this step_

_How do the users test this change?_

  1. Login as an admin.
  2. Create a new user (this requires setting role and agency).
  3. Confirm that the values set correctly.
  4. Add a translation for an agent description value.
  5. Confirm that the values set correctly.

Closes #332.