### PR TITLE
chore(CODEOWNERS): Remove MWallert from Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @karvel @mwallert
+* @karvel


### PR DESCRIPTION
## Changes

  1. Remove @mwallert from being a codeowner of the project. 

## Purpose

@mwallert is no longer actively developing for the platform. As per our engineering meeting, we will be removing him from being a code owner. 

## Approach

Removes @mwallert from CODEOWNERS file. 


Closes #341 
