### PR TITLE
fix,test(infra): Simple token fix

### DIFF
--- a/src/app/infrastructure/core/services/api/auth.service.spec.ts
+++ b/src/app/infrastructure/core/services/api/auth.service.spec.ts
@@ -72,7 +72,7 @@ import { UserStateService } from '../state/user-state.service';
               roleName: 'User',
             },
           },
-          jwtToken:
+          token:
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
         };
       });

--- a/src/app/infrastructure/core/services/api/auth.service.ts
+++ b/src/app/infrastructure/core/services/api/auth.service.ts
@@ -29,9 +29,9 @@ export class AuthService {
     return this.apiService
       .post<ISessionDTO, ILoginRequest>(endpoint, payload)
       .pipe(
-        tap((response) => localStorage.setItem('token', response.jwtToken)),
+        tap((response) => localStorage.setItem('token', response.token)),
         tap((response) => this.userStateService.setUserSession(response.user)),
-        tap((response) => this.setToken(response.jwtToken)),
+        tap((response) => this.setToken(response.token)),
       );
   }
 

--- a/src/app/infrastructure/core/services/api/user.service.spec.ts
+++ b/src/app/infrastructure/core/services/api/user.service.spec.ts
@@ -93,7 +93,7 @@ import { IMessage } from '@models/message';
               roleName: 'User',
             },
           },
-          jwtToken:
+          token:
             'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
         };
       });
@@ -441,7 +441,7 @@ import { IMessage } from '@models/message';
           spyOn(apiService, 'put').and.returnValue(observableOf(expectedValue));
 
           service.changePassword(newPassword, 1).subscribe((response) => {
-            expect(authMock.setToken).toHaveBeenCalledWith(response.jwtToken);
+            expect(authMock.setToken).toHaveBeenCalledWith(response.token);
           });
         });
 

--- a/src/app/infrastructure/core/services/api/user.service.ts
+++ b/src/app/infrastructure/core/services/api/user.service.ts
@@ -156,9 +156,9 @@ export class UserService {
     return this.apiService
       .put<ISessionDTO, IChangePasswordRequest>(endpoint, payload)
       .pipe(
-        tap((response) => localStorage.setItem('token', response.jwtToken)),
+        tap((response) => localStorage.setItem('token', response.token)),
         tap((response) => this.userStateService.setUserSession(response.user)),
-        tap((response) => this.authService.setToken(response.jwtToken)),
+        tap((response) => this.authService.setToken(response.token)),
         tap(() => {
           const message = `Password updated.`;
           return this.notificationService.showSuccess([message]);

--- a/src/app/infrastructure/core/services/state/user-state.service.ts
+++ b/src/app/infrastructure/core/services/state/user-state.service.ts
@@ -23,7 +23,6 @@ export class UserStateService {
   }
 
   public setUserSession(user: IUserDTO): void {
-    debugger;
     localStorage.setItem('user', JSON.stringify(user));
     this.userSession$.next(user);
   }

--- a/src/app/infrastructure/core/services/state/user-state.service.ts
+++ b/src/app/infrastructure/core/services/state/user-state.service.ts
@@ -23,6 +23,7 @@ export class UserStateService {
   }
 
   public setUserSession(user: IUserDTO): void {
+    debugger;
     localStorage.setItem('user', JSON.stringify(user));
     this.userSession$.next(user);
   }

--- a/src/app/infrastructure/models/auth.ts
+++ b/src/app/infrastructure/models/auth.ts
@@ -45,6 +45,6 @@ export class LoginRequest implements ILoginRequest {
 }
 
 export interface ISessionDTO {
-  jwtToken: string;
+  token: string;
   user: IUserDTO;
 }


### PR DESCRIPTION
## Changes
  1. Renames token field to match server. 
  2. Refactors services to use the new name.

## Purpose
To make the client work with the changes from [PR 369](https://github.com/Shift3/boilerplate-server-node/pull/369).

## Approach
This uses the token field now returned by the server and ensures the user can stay logged in by not running JWT-specific checks on the token.

## Testing
1. Login with your user.
2. Logging in should work.
3. If you refresh, open a new tab, or reopen the browser, you should stay logged in.

## Learning
The fix that was implemented on [React BP](https://github.com/Shift3/boilerplate-client-react/pull/518) for this.

Closes #382 
